### PR TITLE
city field in signup admin form search parameters changed

### DIFF
--- a/vms/registration/views.py
+++ b/vms/registration/views.py
@@ -102,7 +102,7 @@ class AdministratorSignupView(TemplateView):
 
                 try:
                     admin_city_name = request.POST.get('city')
-                    admin_city = City.objects.get(pk=admin_city_name)
+                    admin_city = City.objects.get(name=admin_city_name, region=admin_state)
                 except ObjectDoesNotExist:
                     admin_city = None
 

--- a/vms/registration/views.py
+++ b/vms/registration/views.py
@@ -102,7 +102,8 @@ class AdministratorSignupView(TemplateView):
 
                 try:
                     admin_city_name = request.POST.get('city')
-                    admin_city = City.objects.get(name=admin_city_name, region=admin_state)
+                    admin_city = City.objects.get(name=admin_city_name,
+                                                  region=admin_state)
                 except ObjectDoesNotExist:
                     admin_city = None
 


### PR DESCRIPTION
# Description
In the signup-admin, "City" field taken from the form, need to be searched in the "cities_light_city" table by parameters "name" and "region"(to avoid more than one return for the same name") instead of "pk".

Fixes #889

# Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# Checklist:
- [x] I have performed a self-review of my own code or materials


