### PR TITLE
Unique email & phoneNo validation

### DIFF
--- a/vms/administrator/forms.py
+++ b/vms/administrator/forms.py
@@ -16,6 +16,23 @@ class AdministratorForm(forms.ModelForm):
             'phone_number', 'email'
         ]
 
+    def clean_email(self):
+        data = self.cleaned_data['email']
+        data_unchanged = data
+        if "gmail.com" or "googlemail.com" in data:
+            data = data[:-4]
+            if "." in data:
+                data = data.replace(".", "")
+            data = data + '.com'
+            if "googlemail.com" in data:
+                data = data.replace("@googlemail", "@gmail")
+            if '+' in data:
+                i = data.find('+')
+                j = data.find('@')
+                data = data[:i] + data[j:]
+            return data
+        return data_unchanged
+
 
 class ReportForm(forms.Form):
     first_name = forms.RegexField(

--- a/vms/administrator/models.py
+++ b/vms/administrator/models.py
@@ -36,6 +36,7 @@ class Administrator(models.Model):
                 message="Please enter a valid phone number",
             ),
         ],
+        unique=True,
     )
     # Organization to Volunteer is a one-to-many relationship
     organization = models.ForeignKey(Organization)
@@ -45,3 +46,4 @@ class Administrator(models.Model):
 
     def __str__(self):
         return self.user.username
+

--- a/vms/event/tests/test_services.py
+++ b/vms/event/tests/test_services.py
@@ -454,7 +454,7 @@ class EventWithVolunteerTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454546",
             'email': "john@test.com"
         }
         volunteer_3 = {

--- a/vms/job/tests/test_services.py
+++ b/vms/job/tests/test_services.py
@@ -373,7 +373,7 @@ class JobWithShiftTests(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454546",
             'email': "john@test.com"
         }
         volunteer_3 = {

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -225,7 +225,7 @@ class SignUpAdmin(LiveServerTestCase):
             'city': 'Roorkee',
             'state': 'Uttarakhand',
             'country': 'India',
-            'phone_number': '9999999999',
+            'phone_number': '9999999899',
             'organization': 'admin-org'
         }
         page.fill_registration_form(entry)

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -246,7 +246,7 @@ class SignUpVolunteer(LiveServerTestCase):
             'city': 'Roorkee',
             'state': 'Uttarakhand',
             'country': 'India',
-            'phone_number': '9999999999',
+            'phone_number': '9999998999',
             'organization': 'volunteer-org',
             'password': 'volunteer-password1!@#$%^&*()_',
             'confirm_password': 'jddvolunteer-password1!@#$%^&*()_'

--- a/vms/shift/tests/test_manageVolunteerShift.py
+++ b/vms/shift/tests/test_manageVolunteerShift.py
@@ -437,7 +437,7 @@ class ManageVolunteerShift(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.org',
         }
         org_name = 'Google'

--- a/vms/shift/tests/test_services.py
+++ b/vms/shift/tests/test_services.py
@@ -297,8 +297,8 @@ class ShiftWithVolunteerTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "2374983247",
-            'email': "yoshi@nintendo.com"
+            'phone_number': "2374983241",
+            'email': "yoshinn@nintendo.com"
         }
         volunteer_2 = {
             'username': 'John',
@@ -308,7 +308,7 @@ class ShiftWithVolunteerTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454546",
             'email': "john@test.com"
         }
         volunteer_3 = {
@@ -319,7 +319,7 @@ class ShiftWithVolunteerTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454542",
             'email': "ash@pikachu.com"
         }
 
@@ -962,7 +962,7 @@ class ShiftReminderTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "2374983247",
+            'phone_number': "2374983243",
             'email': "jake@nintendo.com"
         }
         volunteer_2 = {

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -151,7 +151,7 @@ class ViewVolunteerShift(LiveServerTestCase):
             'city': second_city,
             'state': second_state,
             'country': second_country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.org'
         }
 

--- a/vms/volunteer/forms.py
+++ b/vms/volunteer/forms.py
@@ -53,3 +53,20 @@ class VolunteerForm(forms.ModelForm):
             'reminder_days'
         ]
 
+    def clean_email(self):
+        data = self.cleaned_data['email']
+        data_unchanged = data
+        if "gmail.com" or "googlemail.com" in data:
+            data = data[:-4]
+            if "." in data:
+                data = data.replace(".", "")
+            data = data + '.com'
+            if "googlemail.com" in data:
+                data = data.replace("@googlemail", "@gmail")
+            if '+' in data:
+                i = data.find('+')
+                j = data.find('@')
+                data = data[:i] + data[j:]
+            return data
+        return data_unchanged
+

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -41,6 +41,7 @@ class Volunteer(models.Model):
                 message="Please enter a valid phone number",
             ),
         ],
+        unique=True,
     )
     # Organization to Volunteer is a one-to-many relationship
     organization = models.ForeignKey(Organization, null=True)

--- a/vms/volunteer/tests/test_searchVolunteer.py
+++ b/vms/volunteer/tests/test_searchVolunteer.py
@@ -157,7 +157,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -177,7 +177,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-name', 'volunteer-last-nameq',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 
@@ -251,7 +251,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
         org_name = 'volunteer-organizationq'
@@ -270,7 +270,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-nameq', 'volunteer-last-name',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 
@@ -351,7 +351,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': second_city,
             'state': second_state,
             'country': second_country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -372,7 +372,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-addressq', 'Bothell,', 'Washington,',
             'United', 'States', 'Washington,', 'United',
             'States', 'United', 'States', 'volunteer-organizationq',
-            '9999999999', 'volunteer-email2@systers.orgq', 'View'
+            '9999999998', 'volunteer-email2@systers.orgq', 'View'
         ]
 
         search_page.search_city_field('Roorkee')
@@ -448,7 +448,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': second_city,
             'state': second_state,
             'country': second_country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -469,7 +469,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-addressq', 'Bothell,', 'Washington,',
             'United', 'States', 'Washington,', 'United',
             'States', 'United', 'States', 'volunteer-organizationq',
-            '9999999999', 'volunteer-email2@systers.orgq', 'View'
+            '9999999998', 'volunteer-email2@systers.orgq', 'View'
         ]
 
         search_page.search_state_field('Uttarakhand')
@@ -546,7 +546,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': second_city,
             'state': second_state,
             'country': second_country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -567,7 +567,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-addressq', 'Bothell,', 'Washington,',
             'United', 'States', 'Washington,', 'United',
             'States', 'United', 'States', 'volunteer-organizationq',
-            '9999999999', 'volunteer-email2@systers.orgq', 'View'
+            '9999999998', 'volunteer-email2@systers.orgq', 'View'
         ]
 
         search_page.search_country_field('India')
@@ -637,7 +637,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -656,7 +656,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-nameq', 'volunteer-last-nameq',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 
@@ -715,7 +715,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -739,7 +739,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-nameq', 'volunteer-last-nameq',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 
@@ -797,7 +797,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -821,7 +821,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-nameq', 'volunteer-last-nameq',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 
@@ -881,7 +881,7 @@ class SearchVolunteer(LiveServerTestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': '9999999999',
+            'phone_number': '9999999998',
             'email': 'volunteer-email2@systers.orgq'
         }
 
@@ -919,7 +919,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-first-nameq', 'volunteer-last-nameq',
             'volunteer-addressq', 'Roorkee,', 'Uttarakhand,',
             'India', 'Uttarakhand,', 'India', 'India',
-            'volunteer-organizationq', '9999999999',
+            'volunteer-organizationq', '9999999998',
             'volunteer-email2@systers.orgq', 'View'
         ]
 

--- a/vms/volunteer/tests/test_services.py
+++ b/vms/volunteer/tests/test_services.py
@@ -32,8 +32,8 @@ class VolunteerMethodTests(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "2374983247",
-            'email': "yoshi@nintendo.com"
+            'phone_number': "2374983249 ",
+            'email': "yoshin@nintendo.com"
         }
         volunteer_2 = {
             'username': 'John',
@@ -54,7 +54,7 @@ class VolunteerMethodTests(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454546",
             'email': "ash@pikachu.com"
         }
         o1 = 'Apple'
@@ -257,7 +257,7 @@ class DeleteVolunteerTest(unittest.TestCase):
             'city': city,
             'state': state,
             'country': country,
-            'phone_number': "23454545",
+            'phone_number': "23454540",
             'email': "john@test.com"
         }
         volunteer_3 = {


### PR DESCRIPTION
# Description
Added a clean method email field so that unique id's like name@gmail.cm and na.me@gmail.com can be identified.Also updated phone_no filed so that only unique phone_no can be used for sign up.

Fixes #660 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Locally by signing up with emails like name@gmail.com  ,  na.me@gmail.com  ,  name@googlemail.com etc.


# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes

