### PR TITLE
Implement feature to show 12 or 24 hour format

### DIFF
--- a/vms/shift/templates/shift/hours_list.html
+++ b/vms/shift/templates/shift/hours_list.html
@@ -22,8 +22,13 @@
                     <tr>
                         <td>{{ shift.job.name }}</td>
                         <td>{{ shift.date }}</td>
+                        {% if is_12_hours_format %}
                         <td>{{ shift.start_time }}</td>
                         <td>{{ shift.end_time }}</td>
+                        {% else %}
+                        <td>{{ shift.start_time|time:"H:i" }}</td>
+                        <td>{{ shift.end_time|time:"H:i" }}</td>
+                        {% endif %}
                         <td><a href="{% url 'shift:add_hours' shift.id user.volunteer.id %}" class="btn btn-info btn-sm">{% trans "Log Hours" %}
                         </a>
                         </td>
@@ -54,8 +59,13 @@
                     <tr>
                         <td>{{ volunteershift.shift.job.name }}</td>
                         <td>{{ volunteershift.shift.date }}</td>
+                        {% if is_12_hours_format %}
                         <td>{{ volunteershift.start_time }}</td>
                         <td>{{ volunteershift.end_time }}</td>
+                        {% else %}
+                        <td>{{ volunteershift.start_time|time:"H:i" }}</td>
+                        <td>{{ volunteershift.end_time|time:"H:i" }}</td>
+                        {% endif %}
                         <td>
                             {% if volunteershift.date_logged >= init_date and not volunteershift.edit_requested  and not volunteershift.report_status %}
                             <a href="{% url 'shift:edit_hours' volunteershift.shift.id user.volunteer.id %}" class="btn btn-primary btn-sm">{% trans "Edit Hours" %}</a>

--- a/vms/shift/templates/shift/volunteer_shifts.html
+++ b/vms/shift/templates/shift/volunteer_shifts.html
@@ -22,8 +22,13 @@
                     <tr>
                         <td>{{ shift.job.name }}</td>
                         <td>{{ shift.date }}</td>
+                        {% if is_12_hours_format %}
                         <td>{{ shift.start_time }}</td>
                         <td>{{ shift.end_time }}</td>
+                        {% else %}
+                        <td>{{ shift.start_time|time:"H:i" }}</td>
+                        <td>{{ shift.end_time|time:"H:i" }}</td>
+                        {% endif %}
                         <td>
                             <a href="{% url 'shift:cancel' shift.id user.volunteer.id %}" class="btn btn-danger btn-sm">{% trans "Cancel Shift Registration" %}</a>
                         </td>

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -22,6 +22,7 @@ from django.views.generic.edit import FormView, UpdateView
 # local Django
 from event.models import Event
 from job.models import Job
+from volunteer.models import Volunteer
 from job.services import get_job_by_id
 from shift.forms import HoursForm, ShiftForm, EditForm
 from shift.models import Shift, EditRequest
@@ -41,6 +42,7 @@ from volunteer.models import Volunteer
 from volunteer.services import get_all_volunteers, search_volunteers
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer
+from volunteer.views import ProfileView
 
 
 class AdministratorLoginRequiredMixin(object):
@@ -820,17 +822,22 @@ class ViewHoursView(LoginRequiredMixin, FormView, TemplateView):
         context['logged_volunteer_shift_list'] = \
             get_volunteer_shifts_with_hours(volunteer_id)
         context['init_date'] = timezone.now() - timedelta(days=7)
+        context['is_12_hours_format'] = Volunteer.objects.get(id=volunteer_id).is_12_hours_format
+        print(context['is_12_hours_format'])
         return context
+
 
 
 @login_required
 @check_correct_volunteer
 @vol_id_check
 def view_volunteer_shifts(request, volunteer_id):
+    is_12_hours_format = Volunteer.objects.get(id=volunteer_id).is_12_hours_format
     shift_list = get_future_shifts_by_volunteer_id(volunteer_id)
     return render(request, 'shift/volunteer_shifts.html', {
         'shift_list': shift_list,
         'volunteer_id': volunteer_id,
+        'is_12_hours_format': is_12_hours_format,
     })
 
 
@@ -865,6 +872,7 @@ class VolunteerSearchView(AdministratorLoginRequiredMixin, FormView):
 @login_required
 def view_volunteers(request, shift_id):
     user = request.user
+
     admin = None
 
     try:
@@ -894,4 +902,3 @@ def view_volunteers(request, shift_id):
                 raise Http404
         else:
             raise Http404
-

--- a/vms/volunteer/forms.py
+++ b/vms/volunteer/forms.py
@@ -53,3 +53,10 @@ class VolunteerForm(forms.ModelForm):
             'reminder_days'
         ]
 
+display_time_format = (
+    ("12_hours", "12 hours"),
+    ("24_hours", "24 hours")
+)
+
+class TimeForm(forms.Form):
+    display_time = forms.ChoiceField(choices=display_time_format)

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -79,7 +79,7 @@ class Volunteer(models.Model):
         blank=True)
 
     user = models.OneToOneField(User)
+    is_12_hours_format = models.BooleanField(default=True)
 
     def __str__(self):
         return '{0} {1}'.format(self.first_name, self.last_name)
-

--- a/vms/volunteer/templates/volunteer/profile.html
+++ b/vms/volunteer/templates/volunteer/profile.html
@@ -110,6 +110,20 @@
                     <a href="{% url 'volunteer:edit' volunteer.id %}" class="btn btn-primary">{% trans "Edit Profile" %}</a>
                 </div>
             </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                      {% trans "Time format" %}
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <form action="" method="post">
+                      {% csrf_token %}
+                      {{form}}
+                      <input type="submit">
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
# Description
Implemented feature to let user choose the display time format(12 or 24 hour format).

Fixes #80

# Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
Changed the code and tested on my local machine.

## Screenshots
Profile page of user with 24 hour as selected time format

![80a](https://user-images.githubusercontent.com/32234630/53111042-50ca1980-3562-11e9-89c2-3dc0a278b5ee.png)

Upcoming shifts

![80b](https://user-images.githubusercontent.com/32234630/53111432-0ac18580-3563-11e9-9866-9d2ce301d96e.png)

Completed shifts

![80f](https://user-images.githubusercontent.com/32234630/53111594-58d68900-3563-11e9-8e6e-d496b2defd05.png)

Profile page with 12 hour as selected time format.

![80c](https://user-images.githubusercontent.com/32234630/53111684-93402600-3563-11e9-8c25-6b2640a0dcc0.png)

Upcoming shifts

![80d](https://user-images.githubusercontent.com/32234630/53111761-b965c600-3563-11e9-9f2a-9a18ba8c9121.png)

Completed shifts

![80e](https://user-images.githubusercontent.com/32234630/53111868-faf67100-3563-11e9-9ff3-481b09b838ed.png)




# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
