### PR TITLE
Updates outdate dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage == 3.7.1
 coveralls == 0.5
-Django == 1.11.0
+Django == 1.11.17
 docopt == 0.6.2
 flake8 == 3.4.1
 psycopg2 == 2.7.4


### PR DESCRIPTION
fixes #929

# Description
Earlier, Django version 1.11.0 was giving a syntax error when building the project. Updating it to 1.11.17 solves this.

Fixes # [ISSUE]
fixes #929 

# Type of Change:
**Delete irrelevant options.**

- Code
- Upgradation of outdated Dependency

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This has been tested by me on my local machine when I was building the project.
![Screenshot from 2020-03-06 12-54-05](https://user-images.githubusercontent.com/42718091/76165615-77172300-617e-11ea-9f7a-1c123794391d.png)
After updating Django this error went away.

# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
