### PR TITLE
fixes issue #889

### DIFF
--- a/vms/registration/views.py
+++ b/vms/registration/views.py
@@ -102,7 +102,7 @@ class AdministratorSignupView(TemplateView):
 
                 try:
                     admin_city_name = request.POST.get('city')
-                    admin_city = City.objects.get(pk=admin_city_name)
+                    admin_city = City.objects.get(name=admin_city_name)
                 except ObjectDoesNotExist:
                     admin_city = None
 
@@ -387,4 +387,3 @@ def load_cities(request):
         'registration/city_dropdown_list_options.html',
         {'cities': cities}
     )
-


### PR DESCRIPTION
# Description
In the administrator Sign Up page, City pk was used instead of city name to filter the query, thus datatype was not matching and the error was displayed .

Fixes #889 

# Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
I have tested the fix by signing up a new administrator and i have tested this multiple times with different cities.


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
