### PR TITLE
fixed broken link to vms in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ reporting.
 
 **This project is under active development.**
 
-VMS is live [here](http://52.8.110.63/).
+VMS is live [here](http://ec2-52-53-177-18.us-west-1.compute.amazonaws.com/en-us/).
 
 If you are an Outreachy Applicant, start with reading [this](https://github.com/systers/ossprojects/wiki/Volunteer-Management-System).
 


### PR DESCRIPTION
I have updated readme file to fix a broken link, now when you click on that link it will redirect you to vms website
Fixes #953 

# Type of Change:

**Delete irrelevant options.**
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
