### PR TITLE
Chore: Use `--no-cache-dir` flag to `pip` in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN mkdir vms
 RUN cd vms
 WORKDIR /usr/src/vms
 COPY requirements.txt /usr/src/vms/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>