### PR TITLE
#1050 UI:Change behaviour of address field in signup admin page 

### DIFF
--- a/vms/registration/templates/registration/signup_administrator.html
+++ b/vms/registration/templates/registration/signup_administrator.html
@@ -206,7 +206,6 @@
                 </div>
             </div>
         {% endif %}
-
             <div id="div_id_country" class="form-group">
                 <label class="control-label">
                 {% trans "Country" %}
@@ -230,14 +229,14 @@
                 <label class="control-label">
                 {% trans "State/Province" %}
                 </label>
-                    <select id="select_state" class="form-control" name="state">
+                    <select disabled id="select_state" class="form-control" name="state">
                     </select>
                 </div>
             <div id="div_id_city" class="form-group">
                 <label class="control-label">
                 {% trans "City" %}
                 </label>
-                    <select id="select_city" class="form-control" name="city">
+                    <select disabled id="select_city" class="form-control" name="city">
                     </select>
              </div>
         {% if administrator_form.phone_number.errors %}

--- a/vms/vms/static/vms/js/load_city.js
+++ b/vms/vms/static/vms/js/load_city.js
@@ -1,6 +1,21 @@
-/** Fetches cities belonging to selected state and country */
 $(document).ready(function() {
     $("#select_state").change(function() {
+	
+/* Disables the city input field until the state input is filled up */
+	function hideCity(){
+	   var country = $("#select_country");
+	   var state = $("#select_state");
+	   var city = $("#select_city"); 
+	   if(state.prop('disabled') === false && state.val() !== null && state.val() !== "0") {
+		city.prop("disabled", false);
+	   }
+	   else {
+		city.prop("disabled", true);
+	   }
+	}
+    hideCity(); 
+
+/** Fetches cities belonging to selected state and country */
         var countryId = $("#select_country").val();
         var stateId = $(this).val();
         $.ajax({
@@ -9,8 +24,15 @@ $(document).ready(function() {
                 "country": countryId,
                 "state": stateId
             },
-            success: function(cities) {
-                $("#select_city").html(cities);
+            success: function(cities) { 
+	var state = $("#select_state");
+	var city = $("#select_city");
+	if(state.val() !== "0" && state.val()!==null && state.prop('disabled') === false) {
+		city.html(cities);
+	}
+	else { 
+		city.empty();
+	}
             }
         });
     });

--- a/vms/vms/static/vms/js/load_state.js
+++ b/vms/vms/static/vms/js/load_state.js
@@ -1,6 +1,28 @@
-/** Fetches states belonging to selected  country */
 $(document).ready(function() {
     $("#select_country").change(function() {
+/* Disables the city and state input field until the country input is filled up */
+	function hideState(){
+		var country = $("#select_country");
+    		var state = $("#select_state");
+		var city = $("#select_city");
+		if(country.val() === "0") {
+			state.prop("disabled", true);
+			city.prop("disabled", true);
+		}
+		if (country.val() !== "0"){
+			state.prop("disabled", false);
+		}
+		if(state.prop('disabled') === false && state.val() !== null && state.val() !== "0") {
+			city.prop("disabled", false);
+		}
+		else {
+			city.prop("disabled", true);
+			city.val("");
+		}
+	}
+	hideState();
+
+/** Fetches states belonging to selected  country */
         var countryId = $(this).val();
         $.ajax({
             url: CheckState,
@@ -16,9 +38,16 @@ $(document).ready(function() {
                             "state": 0
                         },
                         success: function(cities) {
-                            $("#select_city").html(cities);
-                           $("#select_state").empty(); 
-                        }
+    			    var state = $("#select_state");
+			    var city = $("#select_city");
+			    if(state.val() !== "0" && state.val() !== null && state.prop('disabled') === false) {
+               				city.html(cities);
+				}
+				else {
+					city.empty();
+				}
+                         	state.empty(); 
+			 },
                     });
                 } else if (statecheck === true) {
                     $.ajax({
@@ -27,8 +56,10 @@ $(document).ready(function() {
                             "country": countryId
                         },
                         success: function(states) {
-                            $("#select_state").html(states);
-                            $("#select_city").empty();
+    				var state = $("#select_state");
+				var city = $("#select_city");
+				state.html(states);
+                           	city.empty();
                         }
                     });
                 }
@@ -36,4 +67,3 @@ $(document).ready(function() {
         });
     });
 });
-


### PR DESCRIPTION
# Description
In Sign Up Admin, I have made the city and state input disabled until the country is filled first. The city is disabled until the state is filled first.

Fixes #1050 

# Type of Change:
- User Interface

# How Has This Been Tested?
Checked in my local server. Works well according to me. I have handled all the scenarios.
![inputVMS](https://user-images.githubusercontent.com/51945896/92457160-846ea200-f1e1-11ea-9f23-f378e81a5360.gif)


# Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code.



