### PR TITLE
Bug: Toggle top margin on base page

### DIFF
--- a/vms/vms/static/vms/js/marginTop.js
+++ b/vms/vms/static/vms/js/marginTop.js
@@ -1,0 +1,13 @@
+function a() {
+    var targetElem = document.getElementById("blockContainer");
+    targetElem.style.marginTop = "-5px";
+}
+
+function b() {
+    var targetElem = document.getElementById("blockContainer");
+    targetElem.style.marginTop = "100px";
+}
+
+$("button.navbar-toggle.collapsed").click(function () {
+    return (this.tog = !this.tog) ? a() : b();
+});

--- a/vms/vms/templates/vms/base.html
+++ b/vms/vms/templates/vms/base.html
@@ -102,12 +102,14 @@
             </div>
         </div>
 	</div>
-    <div class="container">
+    <div class="container" id="blockContainer">
         {% block content %}
         {% endblock %}
     </div>
     <!-- Bootstrap core JavaScript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
+  <script src="{% static "vms/js/marginTop.js" %}"></script>
+
   </body>
 </html>


### PR DESCRIPTION
In mobile view the top margin of main container in vms/templates/base.html earlier was fixed . When the hamburger icon is clicked and navbar expands the main container then should not have a fixed top margin of 100px. Added onclick function to change margin .
Fixes #1109 

# Type of Change:

- Quality Assurance
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# Mocks 
![Screenshot from 2020-09-24 13-48-47](https://user-images.githubusercontent.com/58214248/94119691-dfa0c580-fe6c-11ea-8331-cfe4579691da.png)
## Before
![Screenshot from 2020-09-09 00-58-10](https://user-images.githubusercontent.com/58214248/94120208-7ff6ea00-fe6d-11ea-9146-037972363b4c.png)


## After
![Screenshot from 2020-09-24 13-48-52](https://user-images.githubusercontent.com/58214248/94119693-e16a8900-fe6c-11ea-8e21-73f0cf510fee.png)


# How Has This Been Tested?
Manually


# Checklist:
**Delete irrelevant options.**

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [X] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)

